### PR TITLE
Proposal: Disable Lint/AmbiguousBlockAssociation

### DIFF
--- a/ruby/default.yml
+++ b/ruby/default.yml
@@ -136,8 +136,6 @@ Layout/TrailingBlankLines:
   Enabled: True
 Layout/TrailingWhitespace:
   Enabled: True
-Lint/AmbiguousBlockAssociation:
-  Enabled: True
 Lint/AmbiguousRegexpLiteral:
   Enabled: True
 Lint/BooleanSymbol:


### PR DESCRIPTION
Rationale: it makes RSpec message assertions a bit
verbose. A message assertion can be used like this:

```
expect(queue).to receive(:delete_message_batch) { |kwargs|
  expect(kwargs[:queue_url]).to eq('https://fake-queue.com')
  #... more assertions on kwargs
  double(ok?: true)
}
```

and we do so in Sqewer, where we need to perform somewhat
elaborate checks on the passed arguments of the message.
I.e. just using `.with(args)` will not suffice.

This issue is usually not that significant, what can be
significant at times is the binding of `do..end` versus
binding of `{}`. For message expectations we know that the
curly-brace block binds last.