### PR TITLE
Adds lint only config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,10 @@ Add a `.rubocop.yml` in the root of you repository, having:
 inherit_gem:
   wetransfer_style: ruby/default.yml
 ```
+
+In case you only want to use rubocop to check for syntax errors:
+
+```
+inherit_gem
+  wetransfer_style: ruby/lint_only.yml
+```

--- a/ruby/lint_only.yml
+++ b/ruby/lint_only.yml
@@ -1,0 +1,7 @@
+AllCops:
+  DisabledByDefault: true
+  TargetRubyVersion: 2.3
+Lint/Syntax:
+  Enabled: True
+Lint/Debugger:
+  Enabled: True


### PR DESCRIPTION
I would like to use rubocop to start linting the frontend repo for syntax errors.