### PR TITLE
Decrease line length severity

### DIFF
--- a/ruby/default.yml
+++ b/ruby/default.yml
@@ -267,7 +267,7 @@ Lint/Void:
 
 Metrics/LineLength:
   Max: 80
-  Severity: warning
+  Severity: refactor
   Enabled: True
 
 Naming/AccessorMethodName:


### PR DESCRIPTION
From the [Ruboguide](https://rubocop.readthedocs.io/en/latest/configuration/#generic-configuration-parameters):
`
Each cop has a default severity level based on which department it belongs to. The level is normally warning for Lint and convention for all the others, but this can be changed in user configuration. 
`

Let's decrease the severity as much as possible and see if it doesn't cause the travis build to fail -- possible editing the `--fail-level`: 
`Minimum severity  for exit with error code. Full severity name or upper case initial can  be given.
`