### PR TITLE
Change FlipFlop namespace to Lint instead of Style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.5
+
+[Changed]
+
+- Changed Style/FlipFlop to Lint/FlipFlop [PR #13](https://github.com/WeTransfer/wetransfer_style/pull/13)
+
 ## 0.6.4
 
 [Added]

--- a/ruby/default.yml
+++ b/ruby/default.yml
@@ -173,6 +173,8 @@ Lint/EndInMethod:
   Enabled: True
 Lint/EnsureReturn:
   Enabled: True
+Lint/FlipFlop:
+  Enabled: True
 Lint/FloatOutOfRange:
   Enabled: True
 Lint/FormatParameterMismatch:
@@ -336,8 +338,6 @@ Style/Encoding:
 Style/EndBlock:
   Enabled: True
 Style/EvenOdd:
-  Enabled: True
-Style/FlipFlop:
   Enabled: True
 Style/For:
   Enabled: True

--- a/wetransfer_style.gemspec
+++ b/wetransfer_style.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "wetransfer_style"
-  s.version = "0.6.4"
+  s.version = "0.6.5"
   s.summary = "At WeTransfer we code in style. This is our style."
   s.description = s.summary
   s.homepage = "https://github.com/WeTransfer/wetransfer_style"


### PR DESCRIPTION
Am getting .../wetransfer_style-0.6.4/ruby/default.yml: Style/FlipFlop has the wrong namespace - should be Lint

This PR should 🤫 the warning.

Changelog and version bump incoming.