### PR TITLE
Set EnforcedStyle: extend_self for Style/ModuleFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.8.0
+
+[Changed]
+
+- Set `EnforcedStyle: extend_self` for `Style/ModuleFunction`
+
 ## 0.7.0
 
 [Changed]

--- a/ruby/default.yml
+++ b/ruby/default.yml
@@ -377,6 +377,9 @@ Style/MixinGrouping:
   Enabled: True
 Style/MixinUsage:
   Enabled: True
+Style/ModuleFunction:
+  Enabled: True
+  EnforcedStyle: extend_self
 Style/MultilineIfThen:
   Enabled: True
 Style/MultilineMemoization:

--- a/wetransfer_style.gemspec
+++ b/wetransfer_style.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "wetransfer_style"
-  s.version = "0.7.0"
+  s.version = "0.8.0"
   s.summary = "At WeTransfer we code in style. This is our style."
   s.description = s.summary
   s.homepage = "https://github.com/WeTransfer/wetransfer_style"


### PR DESCRIPTION
By using `extend self`, we can easily use private methods on modules, for example:

```ruby
module Bla
  extend self

  def call
    do_something
  end

  private

  def do_something
  end
end
```